### PR TITLE
Change the default URI scheme to android.resource and support for loa…

### DIFF
--- a/cucumber-android/src/main/java/cucumber/api/android/CucumberAndroidJUnitRunner.java
+++ b/cucumber-android/src/main/java/cucumber/api/android/CucumberAndroidJUnitRunner.java
@@ -3,6 +3,7 @@ package cucumber.api.android;
 import android.os.Bundle;
 import androidx.test.runner.AndroidJUnitRunner;
 import cucumber.runtime.android.CucumberJUnitRunnerBuilder;
+import java.net.URI;
 
 /**
  * {@link AndroidJUnitRunner} for cucumber tests. It supports running tests from Android Tests Orchestrator
@@ -12,6 +13,8 @@ public class CucumberAndroidJUnitRunner extends AndroidJUnitRunner {
     public static final String CUCUMBER_ANDROID_TEST_CLASS = "cucumberAndroidTestClass";
     private static final String ARGUMENT_ORCHESTRATOR_RUNNER_BUILDER = "runnerBuilder";
     private static final String ARGUMENT_ORCHESTRATOR_CLASS = "class";
+    private static final String ARGUMENT_FEATURES = "features";
+    private static final String ANDROID_RESOURCE_SCHEMA = "android.resource:";
     private Bundle arguments;
 
     @Override
@@ -28,6 +31,19 @@ public class CucumberAndroidJUnitRunner extends AndroidJUnitRunner {
         //because we delegate test execution to CucumberJUnitRunner
         bundle.putString(ARGUMENT_ORCHESTRATOR_CLASS, CucumberJUnitRunnerBuilder.class.getName());
         
+        String features = bundle.getString(ARGUMENT_FEATURES, "");
+        if (features.isEmpty())
+            bundle.putString(ARGUMENT_FEATURES, ANDROID_RESOURCE_SCHEMA + "features");
+        else {
+            try {
+                URI uri = URI.create(features);
+                if (uri.getScheme() == null || uri.getScheme().isEmpty())
+                    bundle.putString(ARGUMENT_FEATURES, ANDROID_RESOURCE_SCHEMA + uri.getSchemeSpecificPart());
+            } catch (IllegalArgumentException e) {
+                //do nothing
+            }
+        }
+
         arguments = bundle;
 
         super.onCreate(bundle);

--- a/cucumber-android/src/main/java/cucumber/runtime/android/AndroidResourceLoader.java
+++ b/cucumber-android/src/main/java/cucumber/runtime/android/AndroidResourceLoader.java
@@ -3,6 +3,7 @@ package cucumber.runtime.android;
 import android.content.Context;
 import android.content.res.AssetManager;
 import cucumber.runtime.CucumberException;
+import cucumber.runtime.io.MultiLoader;
 import cucumber.runtime.io.Resource;
 import cucumber.runtime.io.ResourceLoader;
 
@@ -37,6 +38,13 @@ final class AndroidResourceLoader implements ResourceLoader {
 
     @Override
     public Iterable<Resource> resources(final URI path, final String suffix) {
+        if (!path.getScheme().equals("android.resource")) {
+            MultiLoader multiLoader;
+            multiLoader = new MultiLoader(Thread.currentThread().getContextClassLoader());
+
+            return multiLoader.resources(path, suffix);
+        }
+
         try {
             final List<Resource> resources = new ArrayList<>();
             final AssetManager assetManager = context.getAssets();

--- a/cucumber-android/src/test/java/cucumber/runtime/android/AndroidResourceLoaderTest.java
+++ b/cucumber-android/src/test/java/cucumber/runtime/android/AndroidResourceLoaderTest.java
@@ -41,7 +41,7 @@ public class AndroidResourceLoaderTest {
     public void retrieves_resource_by_given_path_and_suffix() {
 
         // given
-        final URI path = URI.create("file:some/path/some.feature");
+        final URI path = URI.create("android.resource:some/path/some.feature");
         final String suffix = "feature";
 
         // when
@@ -56,7 +56,7 @@ public class AndroidResourceLoaderTest {
     public void retrieves_resources_recursively_from_given_path() throws IOException {
 
         // given
-        final String path = "file:dir";
+        final String path = "android.resource:dir";
         final String dir = "dir";
         final String dirFile = "dir.feature";
         final String subDir = "subdir";
@@ -80,7 +80,7 @@ public class AndroidResourceLoaderTest {
 
         // given
         final String dir = "dir";
-        String path = "file:" + dir;
+        String path = "android.resource:" + dir;
         final String expected = "expected.feature";
         final String unexpected = "unexpected.thingy";
         final String suffix = "feature";


### PR DESCRIPTION
…ding features from Cucumber's underlying multiloader

This is the second option to resolve https://github.com/cucumber/cucumber-android/issues/32

Note that this is a better solution but breaks compatibility with any existing tests that explicitly use file:// as the 'feature' option (in all other cases, this option is parsed out as a URI and default to android.resource) - this should address 99% of use cases.
