### PR TITLE
Update to latest Gradle dependencies as of July 12, 2021.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ env:
   global:
     - ABI=x86_64
     - API=21
-    - ANDROID_BUILD_TOOLS_VERSION=29.0.3
+    - ANDROID_BUILD_TOOLS_VERSION=30.0.2
     - ADB_INSTALL_TIMEOUT=8 # minutes (2 minutes by default)
 android:
   components:

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.4.0'
+    ext.kotlin_version = '1.5.20'
     repositories {
         google()
         jcenter()
@@ -8,7 +8,7 @@ buildscript {
         maven { url 'https://jitpack.io' }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.0.1'
+        classpath 'com.android.tools.build:gradle:4.2.2'
         classpath "com.jaredsburrows:gradle-spoon-plugin:1.5.0"
         classpath "io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.21.2"
         classpath "com.github.marcphilipp.nexus-publish-plugin:nexus-publish-plugin:0.4.0"
@@ -21,7 +21,7 @@ apply plugin: 'io.codearte.nexus-staging'
 
 ext {
     targetSdkVersion = 29
-    buildToolsVersion = '29.0.3'
+    buildToolsVersion = '30.0.2'
     minSdkVersion = '14'
 
     snapshotRepository = "https://oss.sonatype.org/content/repositories/snapshots"
@@ -42,7 +42,7 @@ allprojects {
     repositories {
         mavenLocal()
         google()
-        jcenter()
+        mavenCentral()
         maven {
             url snapshotRepository
         }

--- a/cucumber-android/build.gradle
+++ b/cucumber-android/build.gradle
@@ -18,7 +18,7 @@ dependencies {
     api "io.cucumber:cucumber-java:$cucumber_javaVersion"
     api "io.cucumber:cucumber-junit:$cucumber_javaVersion"
     api 'junit:junit:4.13'
-    api "androidx.test:runner:1.2.0"
+    api "androidx.test:runner:1.4.0"
     testImplementation "org.robolectric:robolectric:4.3.1"
     testImplementation "org.powermock:powermock-api-mockito2:2.0.2"
     testImplementation "org.powermock:powermock-module-junit4:2.0.2"

--- a/cukeulator/build.gradle
+++ b/cukeulator/build.gradle
@@ -75,14 +75,15 @@ dependencies {
     // automatically by Gradle, the flag always bypasses any caching of dependencies.
 
 
-    implementation 'androidx.appcompat:appcompat:1.2.0'
+    implementation 'androidx.appcompat:appcompat:1.3.0'
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 
 //    testImplementation 'junit:junit:4.12'
 //    testImplementation 'org.mockito:mockito-core:2.10.0'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
-    androidTestImplementation 'androidx.test:rules:1.3.0'
-    androidTestUtil 'androidx.test:orchestrator:1.3.0'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
+    androidTestImplementation 'androidx.test:core:1.4.0'
+    androidTestImplementation 'androidx.test:rules:1.4.0'
+    androidTestUtil 'androidx.test:orchestrator:1.4.0'
 
     // Use the stable Cucumber version
     androidTestImplementation project(":cucumber-android")
@@ -211,7 +212,7 @@ def executeAdb(String program) {
  * The path which is used to store the Cucumber files.
  * @return
  */
-def getCucumberDevicePath() {
+static def getCucumberDevicePath() {
     return 'sdcard/Android/data/cucumber.cukeulator/files/reports'
 }
 

--- a/cukeulator/src/androidTest/java/cucumber/cukeulator/test/CalculatorActivitySteps.java
+++ b/cukeulator/src/androidTest/java/cucumber/cukeulator/test/CalculatorActivitySteps.java
@@ -2,8 +2,7 @@ package cucumber.cukeulator.test;
 
 import android.app.Activity;
 
-import androidx.test.rule.ActivityTestRule;
-
+import androidx.test.core.app.ActivityScenario;
 import cucumber.cukeulator.CalculatorActivity;
 import cucumber.cukeulator.R;
 import io.cucumber.java.After;
@@ -18,7 +17,7 @@ import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static org.junit.Assert.assertNotNull;
 
 /**
- * We use {@link ActivityTestRule} in order to have access to methods like getActivity
+ * We use {@link ActivityScenario} in order to have access to methods like getActivity
  * and getInstrumentation.
  * </p>
  * The CucumberOptions annotation is mandatory for exactly one of the classes in the test project.
@@ -35,7 +34,8 @@ public class CalculatorActivitySteps {
      * test lifecycle, activity test rules must not be launched automatically. Automatic launching of test rules is only
      * feasible for JUnit tests. Fortunately, we are able to launch the activity in Cucumber's {@link Before} method.
      */
-    ActivityTestRule rule = new ActivityTestRule<>(CalculatorActivity.class, false, false);
+    private ActivityScenario<CalculatorActivity> scenario;
+    private CalculatorActivity calculatorActivity;
 
     public CalculatorActivitySteps(SomeDependency dependency) {
         assertNotNull(dependency);
@@ -44,20 +44,21 @@ public class CalculatorActivitySteps {
     /**
      * We launch the activity in Cucumber's {@link Before} hook.
      * See the notes above for the reasons why we are doing this.
-     *
-     * @throws Exception any possible Exception
      */
     @Before
-    public void launchActivity() throws Exception {
-        rule.launchActivity(null);
+    public void launchActivity() {
+        scenario = ActivityScenario.launch(CalculatorActivity.class);
+        scenario.onActivity((activity) -> {
+            calculatorActivity = activity;
+        });
     }
 
     /**
      * All the clean up of application's data and state after each scenario must happen here
      */
     @After
-    public void finishActivity() throws Exception {
-        getActivity().finish();
+    public void finishActivity() {
+        scenario.close();
     }
 
     /**
@@ -66,7 +67,7 @@ public class CalculatorActivitySteps {
      * @return the activity
      */
     private Activity getActivity() {
-        return rule.getActivity();
+        return calculatorActivity;
     }
 
     @Given("I have a CalculatorActivity")

--- a/cukeulator/src/androidTest/java/cucumber/cukeulator/test/InstrumentationNonCucumberTest.java
+++ b/cukeulator/src/androidTest/java/cucumber/cukeulator/test/InstrumentationNonCucumberTest.java
@@ -1,15 +1,11 @@
 package cucumber.cukeulator.test;
 
-import android.content.Intent;
-
+import androidx.test.core.app.ActivityScenario;
 import androidx.test.filters.SmallTest;
-import androidx.test.rule.ActivityTestRule;
-
-import org.junit.Before;
-import org.junit.Test;
-
 import cucumber.cukeulator.CalculatorActivity;
 import cucumber.cukeulator.R;
+import org.junit.Before;
+import org.junit.Test;
 
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.action.ViewActions.click;
@@ -22,11 +18,11 @@ import static androidx.test.espresso.matcher.ViewMatchers.withText;
  */
 public class InstrumentationNonCucumberTest {
 
-    private ActivityTestRule<CalculatorActivity> activityTestRule = new ActivityTestRule<>(CalculatorActivity.class, false, false);
+    private ActivityScenario<CalculatorActivity> scenario;
 
     @Before
     public void setUp() throws Exception {
-        activityTestRule.launchActivity(new Intent());
+        scenario = ActivityScenario.launch(CalculatorActivity.class);
     }
 
     @SmallTest

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.6.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip


### PR DESCRIPTION
Updates to different libraries.
<!--- Provide a general summary of your changes in the Title above -->

# Description
- support for latest Gradle dependency versions.
- support for deprecated `ActivityTestRule` in favor of `ActivityScenario`
- Kotlin 1.5
- removed use of jcenter repository in cukeulator module.

# Motivation & context
The demo app uses old dependencies, and deprecated `ActivityTestRule`
_Why is this change required? What problem does it solve?
It fixes dealing with old libraries
