### PR TITLE
Configure Sonatype Nexus Username

### DIFF
--- a/.github/workflows/realease.yml
+++ b/.github/workflows/realease.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
           gpg-passphrase: ${{ secrets.GPG_PASSPHRASE }}
-          nexus-username: cukebot
+          nexus-username: ${{ secrets.SONATYPE_USERNAME }}
           nexus-password: ${{ secrets.SONATYPE_PASSWORD }}
 
   create-github-release:


### PR DESCRIPTION
With Sonatype requiring the usage of a token instead of username/ password. The username can no longer be hardcoded and must also be read from secrets.
