### PR TITLE
Fix code injection via template expansion in GitHub action

### DIFF
--- a/.github/actions/action-publish-gradle/action.yml
+++ b/.github/actions/action-publish-gradle/action.yml
@@ -13,17 +13,13 @@ inputs:
   nexus-password:
     description: Password for your Nexus account
     required: true
-  gradle-tasks:
-    description: Gradle tasks to run
-    required: false
-    default: publishToSonatype closeAndReleaseSonatypeStagingRepository
 
 runs:
   using: "composite"
   steps:
     - name: publish artifacts
       run: |
-        ./gradlew ${{ inputs.gradle-tasks }}
+        ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository
       shell: bash
       env:
         ORG_GRADLE_PROJECT_nexusUsername: ${{ inputs.nexus-username }}


### PR DESCRIPTION
### ⚡️ What's your motivation? 

See: https://docs.zizmor.sh/audits/#template-injection

The input parameter is only used with the default values so we can fix this by inlining those values.

Admittedly, with the action and the and the caller sitting inside the same code base this doesn't do anything other than making the alert go away.

### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)


### 📋 Checklist:


- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
